### PR TITLE
setup build and release action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build and Lint
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_call]
 
 jobs:
   build:
@@ -9,23 +9,29 @@ jobs:
     strategy:
       matrix:
         # the Node.js versions to build on
-        node-version: [10.x, 12.x, 13.x, 14.x, 15.x]
+        node-version: [18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }} 
-        uses: actions/setup-node@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Lint the project
         run: npm run lint
 
       - name: Build the project
         run: npm run build
-        env:
-          CI: true
+
+      - name: List, audit, fix outdated dependencies and build again
+        run: |
+          npm list --outdated
+          npm audit || true  # ignore failures
+          npm audit fix || true
+          npm list --outdated
+          npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build and Lint
 
-on: [push, pull_request, workflow_call]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,31 @@
+name: release-beta.yml
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  publish-to-registry:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to registry
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: npm publish --tag beta --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release.yml
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  publish-to-registry:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to registry
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/MrAsterisco/homebridge-hisense-tv.git"
+    "url": "git+https://github.com/MrAsterisco/homebridge-hisense-tv.git"
   },
   "bugs": {
     "url": "https://github.com/MrAsterisco/homebridge-hisense-tv/issues"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com:MrAsterisco/homebridge-hisense-tv.git"
+    "url": "https://github.com/MrAsterisco/homebridge-hisense-tv.git"
   },
   "bugs": {
-    "url": "http://github.com/MrAsterisco/homebridge-hisense-tv/issues"
+    "url": "https://github.com/MrAsterisco/homebridge-hisense-tv/issues"
   },
   "scripts": {
     "lint": "npm run version && eslint src/**.ts --max-warnings=5 --fix",


### PR DESCRIPTION
- upgraded the build.yml based on the official homebridge-plugin-template
- added a release.yml action to publish npm.js
- changed the repository url based on the documentation [here](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository) because I got a warning when running`npm publish` see below. But the warning still persists even though its documented like that.

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository.url" was normalized to "git://github.com/MrAsterisco/homebridge-hisense-tv.git"
```

@MrAsterisco if these actions are good to go, you need to add your npm token to the repositories secrets. (with the key NPM_TOKEN)