### PR TITLE
V3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### ‼️ WARNING — Read this if upgrading from v2.0.2 or earlier…
+If you are upgrading from v2.0.2 or earlier, please read through the [3.0.0 release notes](#300) as there are breaking changes that require you to update your configuration.
+
+# 3.1.0
+### Changed
+- WoL packets are now sent to the TV’s IP and the correct subnet broadcast address instead of only `255.255.255.255`
+
+### Added
+- Add additional broadcast parameter to config to override the default broadcast address calculation
+
 # 3.0.2
 
 Tested homebridge v2 and found no major issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-### ‼️ WARNING — Read this if upgrading from v2.0.2 or earlier…
+### ‼️ WARNING — Read this if upgrading from v3.0.X or earlier…
+If you are upgrading from v3.0.X or earlier, please read through the [3.1.0 release notes](#310) as there are breaking changes that require you to update your configuration.
 If you are upgrading from v2.0.2 or earlier, please read through the [3.0.0 release notes](#300) as there are breaking changes that require you to update your configuration.
 
 # 3.1.0
+**‼️ Breaking Changes**
+- The uuid generation is now updated to only use the id property of a device.
+  - This change means you have to readd your tv in homebridge (and delete the old version) 
+
 ### Changed
 - WoL packets are now sent to the TV’s IP and the correct subnet broadcast address instead of only `255.255.255.255`
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -27,7 +27,7 @@
               "type": "string",
               "required": true,
               "default": "HiSenseTV",
-              "description": "A unique identifier of this device. You can use the device model, the S/N or any other random string. This will be displayed as Serial Number in Home."
+              "description": "A unique identifier of this device. You can use the the S/N or any other random string. This will be displayed as Serial Number in Home. If you change this id, you would need to readd your device in the home app."
             },
             "name": {
               "title": "Name",

--- a/config.schema.json
+++ b/config.schema.json
@@ -130,7 +130,7 @@
               "description": "The number of WOL packets sent continuously to wake up the tv to account for packet loss."
             },
             "ipaddress": {
-              "title": "IP Address",
+              "title": "TV IP Address",
               "type": "string",
               "required": true,
               "format": "ipv4",
@@ -138,11 +138,19 @@
               "description": "This plugin cannot discover TVs automatically on the local network. Make sure to set your TV with a static DHCP to the IP address you input here."
             },
             "macaddress": {
-              "title": "MAC Address",
+              "title": "TV MAC Address",
               "type": "string",
               "required": true,
               "placeholder": "00:XX:00:XX:00:XX",
               "description": "In order to be able to turn on the TV when it's off, insert your TV's MAC Address. Make sure to use the MAC Address of the network interface (WiFi or Ethernet) you're using and also turn on 'Wake on LAN' and 'Wake on WiFi' in your TV settings."
+            },
+            "broadcast": {
+              "title": "TV Broadcast Address",
+              "type": "string",
+              "required": false,
+              "format": "ipv4",
+              "placeholder": "192.168.1.255",
+              "description": "The address where wake on lan packets should go to. Usually its the networks broadcast address. Only necessary in special cases. If not specified, a default will be set based on the TV IP address and all available network interfaces."
             },
             "sslmode": {
               "title": "SSL mode",
@@ -272,6 +280,9 @@
             "functionBody": "return model.devices[arrayIndices].tvType === 'default';"
           },
           "items": [
+            {
+              "key": "devices[].broadcast"
+            },
             {
               "key": "devices[].pollingInterval"
             },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "HiSense TV",
   "name": "homebridge-hisense-tv-remotenow",
-  "version": "3.1.0-beta.0",
+  "version": "3.1.0-beta.1",
   "description": "Control RemoteNow-enabled HiSense TVs.",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "HiSense TV",
   "name": "homebridge-hisense-tv-remotenow",
-  "version": "3.0.2",
+  "version": "3.1.0-beta.0",
   "description": "Control RemoteNow-enabled HiSense TVs.",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/interfaces/device-config.interface.ts
+++ b/src/interfaces/device-config.interface.ts
@@ -7,6 +7,7 @@ export interface DeviceConfig {
     menuId: number;
     menuFlag: number;
   };
+  broadcast?: string;
   name: string;
   pollingInterval: number;
   wolInterval: number;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -63,7 +63,7 @@ export class HiSenseTVPlatform implements IndependentPlatformPlugin {
       // generate a unique id for the accessory this should be generated from
       // something globally unique, but constant, for example, the device serial
       // number or MAC address
-      const uuid = this.api.hap.uuid.generate(device.id+device.name);
+      const uuid = this.api.hap.uuid.generate(device.id+device.macaddress);
 
       // the accessory does not yet exist, so we need to create it
       this.log.info('Adding new accessory:', device.name);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,4 +1,12 @@
-import {API, DynamicPlatformPlugin, PlatformAccessory, PlatformConfig, Service, Characteristic, Categories, Logging} from 'homebridge';
+import {
+  API,
+  PlatformConfig,
+  Service,
+  Characteristic,
+  Categories,
+  Logging,
+  IndependentPlatformPlugin,
+} from 'homebridge';
 
 import { PLUGIN_NAME } from './settings.js';
 import { HiSenseTVAccessory } from './platformAccessory.js';
@@ -10,17 +18,14 @@ import {validateHomeKitName} from './utils/validateHomeKitName.function.js';
  * This class is the main constructor for your plugin, this is where you should
  * parse the user config and discover/register accessories with Homebridge.
  */
-export class HiSenseTVPlatform implements DynamicPlatformPlugin {
+export class HiSenseTVPlatform implements IndependentPlatformPlugin {
   public readonly Service: typeof Service;
   public readonly Characteristic: typeof Characteristic;
 
-  // this is used to track restored cached accessories
-  public readonly accessories: PlatformAccessory[] = [];
-
   constructor(
-    public readonly log: Logging,
-    public readonly config: PlatformConfig,
-    public readonly api: API,
+      public readonly log: Logging,
+      public readonly config: PlatformConfig,
+      public readonly api: API,
   ) {
     this.Service = this.api.hap.Service;
     this.Characteristic = this.api.hap.Characteristic;
@@ -33,10 +38,15 @@ export class HiSenseTVPlatform implements DynamicPlatformPlugin {
       log.success = log.info;
     }
 
+    // comment from homebridge-team
     // When this event is fired it means Homebridge has restored all cached accessories from disk.
     // Dynamic Platform plugins should only register new accessories after this event was fired,
     // in order to ensure they weren't added to homebridge already. This event can also be used
     // to start discovery of new accessories.
+
+    // comment from maintainer
+    // We don't have a DynamicPlatformPlugin, so we don't necessarily have to wait for this event,
+    // but we will do it anyway to be safe.
     this.api.on('didFinishLaunching', () => {
       log.debug('Executed didFinishLaunching callback');
       // run the method to discover / register your devices as accessories
@@ -44,21 +54,6 @@ export class HiSenseTVPlatform implements DynamicPlatformPlugin {
     });
   }
 
-  /**
-   * This function is invoked when homebridge restores cached accessories from disk at startup.
-   * It should be used to setup event handlers for characteristics and update respective values.
-   */
-  configureAccessory(accessory: PlatformAccessory) {
-    this.log.info('Loading accessory from cache:', accessory.displayName);
-
-    // add the restored accessory to the accessories cache so we can track if it has already been registered
-    this.accessories.push(accessory);
-  }
-
-  /**
-   * As we are only publishing external accessories, they don't get stored in the cache.
-   * So only the else is important here.
-   */
   discoverDevices() {
     const configDevices = this.config.devices as DeviceConfig[] || [];
 
@@ -70,49 +65,23 @@ export class HiSenseTVPlatform implements DynamicPlatformPlugin {
       // number or MAC address
       const uuid = this.api.hap.uuid.generate(device.id+device.name);
 
-      // see if an accessory with the same uuid has already been registered and restored from
-      // the cached devices we stored in the `configureAccessory` method above
-      const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
+      // the accessory does not yet exist, so we need to create it
+      this.log.info('Adding new accessory:', device.name);
 
-      if (existingAccessory) {
-        // the accessory already exists
-        this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
+      // create a new accessory
+      const accessory = new this.api.platformAccessory(validateHomeKitName(device.name), uuid, Categories.TELEVISION);
 
-        // if you need to update the accessory.context then you should run `api.updatePlatformAccessories`. eg.:
-        // existingAccessory.context.device = device;
-        // this.api.updatePlatformAccessories([existingAccessory]);
+      // store a copy of the device object in the `accessory.context`
+      // the `context` property can be used to store any data about the accessory you may need
+      accessory.context.device = device;
+      accessory.context.macaddress = this.config.macaddress;
 
-        // create the accessory handler for the restored accessory
-        // this is imported from `platformAccessory.ts`
-        new HiSenseTVAccessory(this, existingAccessory);
+      // create the accessory handler for the newly create accessory
+      // this is imported from `platformAccessory.ts`
+      new HiSenseTVAccessory(this, accessory);
 
-        // update accessory cache with any changes to the accessory details and information
-        //this.api.updatePlatformAccessories([existingAccessory]);
-
-        // it is possible to remove platform accessories at any time using `api.unregisterPlatformAccessories`, eg.:
-        // remove platform accessories when no longer present
-        //this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
-        //this.log.info('Removing existing accessory from cache:', existingAccessory.displayName);
-      } else {
-        // the accessory does not yet exist, so we need to create it
-        this.log.info('Adding new accessory:', device.name);
-
-        // create a new accessory
-        const accessory = new this.api.platformAccessory(validateHomeKitName(device.name), uuid, Categories.TELEVISION);
-
-        // store a copy of the device object in the `accessory.context`
-        // the `context` property can be used to store any data about the accessory you may need
-        accessory.context.device = device;
-        accessory.context.macaddress = this.config.macaddress;
-
-        // create the accessory handler for the newly create accessory
-        // this is imported from `platformAccessory.ts`
-        new HiSenseTVAccessory(this, accessory);
-
-        // link the accessory to your platform
-        this.api.publishExternalAccessories(PLUGIN_NAME, [accessory]);
-        // this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
-      }
+      // link the accessory to your platform
+      this.api.publishExternalAccessories(PLUGIN_NAME, [accessory]);
     }
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -63,7 +63,7 @@ export class HiSenseTVPlatform implements IndependentPlatformPlugin {
       // generate a unique id for the accessory this should be generated from
       // something globally unique, but constant, for example, the device serial
       // number or MAC address
-      const uuid = this.api.hap.uuid.generate(device.id+device.macaddress);
+      const uuid = this.api.hap.uuid.generate(`homebridge-hisense-tv:${device.id}`);
 
       // the accessory does not yet exist, so we need to create it
       this.log.info('Adding new accessory:', device.name);

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -79,7 +79,7 @@ export class HiSenseTVAccessory {
 
     // create useful subclasses
     this.inputSourceSubPlatformAccessory = new InputSourceSubPlatformAccessory(this.Service, accessory, this.Characteristic);
-    this.wol = new WoL(this.log, this.deviceConfig.macaddress, this.deviceConfig.wolRetries, this.deviceConfig.wolInterval);
+    this.wol = new WoL(this.log, this.deviceConfig.macaddress, this.deviceConfig.ipaddress, this.deviceConfig.wolRetries, this.deviceConfig.wolInterval, this.deviceConfig.broadcast);
 
     // Configure the TV details.
     this.accessory.getService(this.Service.AccessoryInformation)!

--- a/src/wol.ts
+++ b/src/wol.ts
@@ -1,5 +1,42 @@
 import {Logging} from 'homebridge';
 import wol from 'wol';
+import os from 'node:os';
+
+/**
+ * Convert IPv4 string (e.g. "192.168.1.5") to a 32-bit unsigned int
+ */
+const ipv4ToInt = (ip: string) => ip.split('.').reduce((n, o) => (n << 8) + (+o), 0) >>> 0;
+
+/**
+ * Convert 32-bit unsigned int back to dotted IPv4 string
+ */
+const intToIpv4 = (n: number) => [24, 16, 8, 0].map(s => (n >>> s) & 255).join('.');
+
+/**
+ * Check whether two IPv4 addresses are in the same subnet given a netmask
+ */
+const sameSubnet = (ipA: string, ipB: string, mask: string) => {
+  const a = ipv4ToInt(ipA);
+  const b = ipv4ToInt(ipB);
+  const m = ipv4ToInt(mask);
+  return ((a & m) >>> 0) === ((b & m) >>> 0);
+};
+
+/**
+ * Calculate the directed broadcast address for an IP + netmask
+ */
+const directedBroadcast = (ip: string, mask: string) => {
+  const ipN = ipv4ToInt(ip);
+  const m = ipv4ToInt(mask);
+  const bcast = (ipN | (~m >>> 0)) >>> 0; // equivalent to ((ipN & m) | (~m >>> 0))
+  return intToIpv4(bcast);
+};
+
+
+interface Nic {
+    localIp: string;
+    netmask: string;
+}
 
 /**
  * Wake on Lan
@@ -8,28 +45,78 @@ export class WoL {
   /**
    * @param log Homebridge logger
    * @param macAddress MAC address of the device to wake up
+   * @param tvIp IP address of the device to wake up
    * @param retries Number of retries to send the magic packet
    * @param interval Interval between retries in milliseconds
+   * @param broadcast (Optional) Broadcast address to use. If not provided, the broadcast address will be calculated based on the NIC in the same subnet as the TV IP address.
    */
   constructor(private log: Logging, private macAddress: string, private tvIp: string, private retries: number, private interval: number, private broadcast: string|undefined) {
   }
 
 
   /**
-   * Send the magic packet to wake up the device
-   * @param attempt Current attempt
+   * Picks a network interface card (NIC) that is in the same subnet as the TV IP address.
+   * @param tvIp
    */
-  public async sendMagicPacket(attempt = 0) {
-    if(attempt < this.retries){
-      try {
-        await wol.wake(this.macAddress);
-        this.log.debug('Send Wake On Lan');
-        setTimeout(() => {
-          this.sendMagicPacket(attempt + 1);
-        }, this.interval ?? 400);
-      } catch (error) {
-        this.log.error('An error occurred while sending WoL: ' + error);
+  public pickNicFor(tvIp: string): Nic|undefined {
+    const nics = [] as Nic[];
+    for (const addrs of Object.values(os.networkInterfaces())) {
+      for (const a of addrs || []) {
+        if (a.family === 'IPv4' && !a.internal && a.netmask && sameSubnet(tvIp, a.address, a.netmask)) {
+          nics.push({localIp: a.address, netmask: a.netmask});
+        }
       }
     }
+
+    if(nics.length === 1){
+      return nics[0];
+    }else if(nics.length > 1){
+      this.log.info('Multiple NICs found in same subnet as ' + tvIp);
+      this.log.info('Please configure a broadcast address manually in case the TV does not wake up.');
+
+      // return the one with the most specific network mask (i.e. the highest number of bits set to 1)
+      return nics.sort((a, b) => ipv4ToInt(b.netmask) - ipv4ToInt(a.netmask))[0];
+    }else{
+      this.log.warn('No NIC found in same subnet as ' + tvIp + ', please configure a broadcast address manually.');
+
+      return undefined;
+    }
+
+  }
+
+  private async sendPackets(ipAddress: string|undefined, attempt = 0) {
+    if (attempt < this.retries) {
+      try {
+        await wol.wake(this.macAddress, ipAddress ? { address: ipAddress} : undefined);
+        this.log.debug('Send Wake On Lan');
+      } catch (error) {
+        this.log.error('An error occurred while sending WoL: ' + error);
+      }finally {
+        setTimeout(() => {
+          this.sendPackets(ipAddress, attempt + 1);
+        }, this.interval ?? 400);
+      }
+    }
+  }
+
+  /**
+     * Triggers sending the magic packet to wake up the TV.
+     */
+  public sendMagicPacket() {
+    let nic: Nic | undefined = undefined;
+    // if we have a broadcast address, we don't need to pick a NIC
+    nic = this.broadcast ? undefined : this.pickNicFor(this.tvIp);
+
+    if(nic){
+      this.log.debug('Using NIC with local IP ' + nic.localIp + ' and netmask ' + nic.netmask);
+      // send additional packets to the directed broadcast address of the NIC
+      void this.sendPackets(directedBroadcast(nic.localIp, nic.netmask));
+    }
+    if(this.broadcast){
+      void this.sendPackets(this.broadcast);
+    }
+
+    // always send additional packets to the tvIp directly
+    void this.sendPackets(this.tvIp);
   }
 }

--- a/src/wol.ts
+++ b/src/wol.ts
@@ -11,7 +11,7 @@ export class WoL {
    * @param retries Number of retries to send the magic packet
    * @param interval Interval between retries in milliseconds
    */
-  constructor(private log: Logging, private macAddress: string, private retries: number, private interval: number){
+  constructor(private log: Logging, private macAddress: string, private tvIp: string, private retries: number, private interval: number, private broadcast: string|undefined) {
   }
 
 


### PR DESCRIPTION
This pull request introduces several improvements and a new configuration option to enhance Wake-on-LAN (WoL) reliability and flexibility for HiSense TVs. The main changes include sending WoL packets to both the TV’s IP address and the correct subnet broadcast address, allowing users to specify a custom broadcast address in the configuration, and updating the WoL logic to select the best network interface automatically. There are also schema and documentation updates to reflect these changes.

### Wake-on-LAN improvements
* WoL packets are now sent to both the TV’s IP address and the correct subnet broadcast address, improving reliability over only using `255.255.255.255`. The WoL logic now automatically selects the appropriate network interface and calculates the broadcast address, with fallback and logging if no suitable NIC is found. (`src/wol.ts`, `src/platformAccessory.ts`) (F0215c17L1, [[1]](diffhunk://#diff-d712d1b5cc267c1380f88ce1aa904811a0a8022ac664b606e7fc36e55bda3958R48-R120) [[2]](diffhunk://#diff-e3e5a8bcb65529d3b9988acc9d4c55b85fbc6448682cdb51e39409790dda4cdaL82-R82)

### Configuration enhancements
* Added an optional `broadcast` parameter to the device configuration, allowing users to override the default broadcast address calculation for special network setups. This is reflected in the schema, TypeScript interfaces, and user documentation. (`config.schema.json`, `src/interfaces/device-config.interface.ts`, `CHANGELOG.md`) [[1]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5L133-R154) [[2]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5R283-R285) [[3]](diffhunk://#diff-be8a14e0068d955e2abec741e494332ca9ae79d059d9a8f0330df86d666755efR10) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R10)

### Platform architecture updates
* Migrated from `DynamicPlatformPlugin` to `IndependentPlatformPlugin` for better alignment with Homebridge architecture, and simplified accessory management by removing cache logic and related event handling. (`src/platform.ts`) [[1]](diffhunk://#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81L1-R9) [[2]](diffhunk://#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81L13-L19) [[3]](diffhunk://#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81R41-L61) [[4]](diffhunk://#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81L71-L96) [[5]](diffhunk://#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81L114-L115)

### Documentation and versioning
* Updated the changelog to warn users about breaking changes since v2.0.2 and added details for the new WoL behavior and configuration option. Bumped the package version to `3.1.0-beta.0`. (`CHANGELOG.md`, `package.json`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R10) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4)